### PR TITLE
Secure Session Cookie

### DIFF
--- a/src/check.php
+++ b/src/check.php
@@ -2,20 +2,10 @@
 require_once("function/encryption.php");
 require_once("function/sqllink.php");
 session_start();
-$currentCookieParams = session_get_cookie_params();  
 $token = $_SESSION['session_token'];
 session_regenerate_id(true);
 $_SESSION['session_token'] = $token;
 $sidvalue = session_id();  
-setcookie(  
-    session_name(),//name  
-    $sidvalue,//value  
-    0,//expires at end of session  
-    $currentCookieParams['path'],//path  
-    $currentCookieParams['domain'],//domain  
-    $currentCookieParams['secure'], //secure 
-    true 
-);
 function getUserIP()
 {
     $remote  = $_SERVER['REMOTE_ADDR'];

--- a/src/function/sqllink.php
+++ b/src/function/sqllink.php
@@ -66,4 +66,6 @@ function checksession($link)
 	setcookie("ServerRenew", "1");
     return TRUE;
 }   
+$currentCookieParams = session_get_cookie_params();  
+session_set_cookie_params(0, $currentCookieParams['path'], $currentCookieParams['domain'], (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || $_SERVER['SERVER_PORT'] == 443, true);
 ?>

--- a/src/index.php
+++ b/src/index.php
@@ -2,17 +2,6 @@
 require_once('function/basic.php');
 require_once("function/sqllink.php");
 session_start();
-$currentCookieParams = session_get_cookie_params();  
-$sidvalue = session_id();  
-setcookie(  
-    session_name(),//name  
-    $sidvalue,//value  
-    0,//expires at end of session  
-    $currentCookieParams['path'],//path  
-    $currentCookieParams['domain'],//domain  
-    (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || $_SERVER['SERVER_PORT'] == 443, //secure 
-    true
-);
 if(isset($_SESSION["loginok"])&& $_SESSION['loginok']==1) {header("Location: ./password.php"); die();}
 if(!isset($_SESSION['random_login_stamp'])) $_SESSION['random_login_stamp']=date("Ymdhis").mt_rand(10000,99999);
 $_SESSION['session_token']=bin2hex(openssl_random_pseudo_bytes(32));

--- a/src/logout.php
+++ b/src/logout.php
@@ -1,4 +1,5 @@
 <?php
+require_once("function/sqllink.php");
 session_start();
 if(isset($_SESSION['loginok'])) unset($_SESSION['loginok']);
 if(isset($_SESSION['user'])) unset($_SESSION['user']);
@@ -6,11 +7,6 @@ if(isset($_SESSION['pwd'])) unset($_SESSION['pwd']);
 if(isset($_SESSION['fields'])) unset($_SESSION['fields']);
 if(isset($_SESSION['userid'])) unset($_SESSION['userid']);
 if(isset($_SESSION['random_login_stamp'])) unset($_SESSION['random_login_stamp']);
-$params = session_get_cookie_params();
-setcookie(session_name(), '', time() - 42000,
-    $params["path"], $params["domain"],
-    $params["secure"], $params["httponly"]
-);
 session_regenerate_id(true);//as suggested by owasp, change sessionId when changing context
 session_destroy();
 $reason = "";


### PR DESCRIPTION
closes #114 
Just calling
```
<?php
session_start();
session_destroy();
?>
```
doesn't work as it uses the default settings(secure not set).