### PR TITLE
Allow disabling of Signup

### DIFF
--- a/src/function/config.php
+++ b/src/function/config.php
@@ -36,6 +36,9 @@ $FILE_ENABLED = True;
 //Allow Password-Manager to store files? True -- YES; False -- NO
 //Disabling File feature will hide API on user screen, but the backend won't change.
 
+//Allow new user signup
+$ALLOW_SIGN_UP = True;
+
 //PIN expire
 $PIN_EXPIRE_TIME=7776000; 
 //PIN expire in 7776000 seconds.

--- a/src/index.php
+++ b/src/index.php
@@ -86,7 +86,7 @@ if(!isAllHTML5Supports()) {
         <span id="accountban" class="errorhint"  style="display:none; color:Red">Your account has been protected due to continuous attack. Try again in <?php echo $ACCOUNT_BAN_TIME;?> seconds<br /></span>
         <span id="othererror" class="errorhint"  style="display:none; color:Red">Oops, our server run into some problems. Please refresh this page and try again.<br /></span>
         <hr />
-        <button class="btn btn-sm btn-default" type="button" onClick="window.location.href='signup.php';" >Sign Up</button>&nbsp; <button class="btn btn-sm btn-warning" type="button" onClick="window.location.href='recovery.php';" >Password Recovery</button>
+        <button class="btn btn-sm btn-default<?php if ($ALLOW_SIGN_UP === False) echo " hidden";?>" type="button" onClick="window.location.href='signup.php';" >Sign Up</button>&nbsp; <button class="btn btn-sm btn-warning" type="button" onClick="window.location.href='recovery.php';" >Password Recovery</button>
     <hr />
     <div>Version <?php echo $VERSION;?> (<a href="https://github.com/zeruniverse/Password-Manager/releases">DOWNLOAD</a>)</div>
     <div class="modal" tabindex="-1" role="dialog" id="usepin">

--- a/src/reg.php
+++ b/src/reg.php
@@ -5,6 +5,11 @@ $email=$_POST['email'];
 if($pw==''||$usr==''||$email=="")die("7");
 require_once("function/sqllink.php");
 require_once("function/encryption.php");
+require_once("function/config.php");
+if ($ALLOW_SIGN_UP === False){
+    http_response_code(405);
+    die('Method not allowed');
+}
 $link=sqllink();
 if(!$link) die('6');
 if(!$link->beginTransaction()) die('4');

--- a/src/signup.php
+++ b/src/signup.php
@@ -12,7 +12,11 @@ echoheader();
 	</div>
 	<h3>New User</h3>
     <p>Only numbers and letters are allowed for username</p>
-	<form style="max-width:300px;">
+    <?php
+    if ($ALLOW_SIGN_UP === False)
+        echo '<div id="message" class="alert alert-info"><a href="#" class="close" data-dismiss="alert" aria-label="close">×</a><span id="messageText">Signup is not allowed.</span></div>';
+    ?>
+	<form style="max-width:300px;<?php if ($ALLOW_SIGN_UP === False) echo " hidden";?>">
         <div class="form-group">
             <label for="user" class="control-label">User Name: </label>
             <input type="text" class="form-control" name="user" id="user" />
@@ -54,23 +58,21 @@ var JSsalt='<?php echo $GLOBAL_SALT_1;?>';
         $.post("reg.php",{email:$("#email").val(), pwd:String(CryptoJS.SHA512(login_sig+$("#user").val())),  user: $("#user").val()},function(msg){ 
 		if(msg==0){
 			 	alert("User name already occupied, please choose another user name.");
-				$("#chk").attr("value", "Submit");
-				$("#chk").attr("disabled", false);
 		}else
 		if(msg==1){
 			 	alert("This E-mail has already been used.");
-				$("#chk").attr("value", "Submit");
-				$("#chk").attr("disabled", false);
 		}else
 		if(msg==9){
 			 	alert("Successfully signup, now please sign in!");
 			 	window.location.href="index.php";
-		}else{
+        }else
+        if(msg=="Method not allowed") {
+            alert("Signup is not allowed.");
+        }else{
                 alert("There're some errors, please retry");
-				$("#chk").attr("value", "Submit");
-				$("#chk").attr("disabled", false);
 		}
-		 
+        $("#chk").attr("value", "Submit");
+        $("#chk").attr("disabled", false);
         }); 
         }
         setTimeout(process,50);

--- a/src/signup.php
+++ b/src/signup.php
@@ -16,7 +16,7 @@ echoheader();
     if ($ALLOW_SIGN_UP === False)
         echo '<div id="message" class="alert alert-info"><a href="#" class="close" data-dismiss="alert" aria-label="close">×</a><span id="messageText">Signup is not allowed.</span></div>';
     ?>
-	<form style="max-width:300px;<?php if ($ALLOW_SIGN_UP === False) echo " hidden";?>">
+	<form style="max-width:300px;" <?php if ($ALLOW_SIGN_UP === False) echo 'class="hidden"';?>>
         <div class="form-group">
             <label for="user" class="control-label">User Name: </label>
             <input type="text" class="form-control" name="user" id="user" />
@@ -33,8 +33,8 @@ echoheader();
             <label for="email" class="control-label">Email:</label>
             <input type="text" class="form-control"name="email" id="email" />
         </div>
+        <input type="button" class="btn btn-md btn-success" id="chk"  value="Submit" />
     </form>
-    <input type="button" class="btn btn-md btn-success" id="chk"  value="Submit" />
 <script type="text/javascript">
 var JSsalt='<?php echo $GLOBAL_SALT_1;?>';
     function isEmail(aEmail) {


### PR DESCRIPTION
This pull request allows to set the option `$ALLOW_SIGN_UP` to `False` to disable signing up for new users.

Setting this option disables the buttons and forms for signing up and disabled the functionality in the backend. Sending a request for signing up with the flag set to `False` leads to an html error `405 - Method not allowed`.