### PR TITLE
add option for customize-field

### DIFF
--- a/src/function/config.php
+++ b/src/function/config.php
@@ -39,6 +39,9 @@ $FILE_ENABLED = True;
 //Allow new user signup
 $ALLOW_SIGN_UP = True;
 
+//Allow users to be able to use the 'Customize fields' option
+$CUSTOMIZE_FIELDS=True;
+
 //PIN expire
 $PIN_EXPIRE_TIME=7776000; 
 //PIN expire in 7776000 seconds.

--- a/src/password.php
+++ b/src/password.php
@@ -1,5 +1,6 @@
 <?php
 require_once("function/basic.php");
+require_once("function/config.php");
 echoheader();
 ?>
 <style type="text/css">
@@ -121,7 +122,7 @@ function checksessionalive()
               <li><a href="" data-toggle="modal" data-target="#import">Import</a></li>
               <li><a href="javascript: exportcsv();">Export CSV</a></li>
               <li><a href="" data-toggle="modal" data-target="#changepwd">Change Password</a></li>
-              <li><a href="" data-toggle="modal" data-target="#changefields">Customize Fields</a></li>
+              <?php if($CUSTOMIZE_FIELDS) echo '<li><a href="" data-toggle="modal" data-target="#changefields">Customize Fields</a></li>';?>
               <li><a href="javascript: $('#historyformsesstoken').val(localStorage.session_token); $('#historyform').submit();">Account Activity</a></li>
             </ul>
             </li>


### PR DESCRIPTION
Added an option to allow or not the customize-field's panel.

It requires `require_once("function/config.php");` in `password.php`, I hope it is not a problem.