### PR TITLE
rename "passwordlastchangtime_01_system"

### DIFF
--- a/src/js/plugins/showPasswordAge.js
+++ b/src/js/plugins/showPasswordAge.js
@@ -18,7 +18,9 @@ registerPlugin("editAccountDialog",function(data){
         return time;
     }
     var account = data["account"];
-    $("#edititempasswordlastchanged").text(timeConverter(lasttimechangearray[account["index"]]));
+    if ("_system_passwordLastChangeTime" in account["index"]["other"]) {
+        $("#edititempasswordlastchanged").text(timeConverter(account["index"]["other"]["_system_passwordLastChangeTime"]));
+    }
 });
 registerPlugin("layoutReady",function(data){
     $("label[for='edititeminputpw']").after($("<span>")

--- a/src/rest/password.php
+++ b/src/rest/password.php
@@ -47,7 +47,8 @@ $result["loginInformation"] = array( "lastLogin" => $data["time"] );
 // Select failed login attempts
 $sql = "SELECT COUNT(*) AS `failedLogins` FROM `history` WHERE `userid` = ? AND `outcome` = 0 AND `id` > ?";
 $res = sqlexec($sql, array($id, $loginID),$link);
-$result["loginInformation"]["failedCount"] = (int)$res->fetch(PDO::FETCH_ASSOC)["failedLogins"];
+$data = $res->fetch(PDO::FETCH_ASSOC);
+$result["loginInformation"]["failedCount"] = (int)$data["failedLogins"];
 
 echo json_encode($result);
 ?>


### PR DESCRIPTION
If a user upgrades the "passwordlastchangtime_01_system" field will still be saved with every account, but not displayed. Whenever an account password is updated with a new password the new field will be set.

Is that ok?

I could write an update routine(I've been thinking about it for a while now), but this would take at least another week.