### PR TITLE
fix showPasswordAge

### DIFF
--- a/src/js/plugins/showPasswordAge.js
+++ b/src/js/plugins/showPasswordAge.js
@@ -21,6 +21,8 @@ registerPlugin("editAccountDialog",function(data){
     if ("_system_passwordLastChangeTime" in account["other"]) {
         $("#edititempasswordlastchanged").text(timeConverter(account["other"]["_system_passwordLastChangeTime"]));
     }
+    else
+        $("#edititempasswordlastchanged").empty();
 });
 registerPlugin("layoutReady",function(data){
     $("label[for='edititeminputpw']").after($("<span>")


### PR DESCRIPTION
bug: showed the last loaded entry on editing when the current 
account doesn't have password age set