### PR TITLE
add length check to prevent denial of service attacks

### DIFF
--- a/src/rest/changeuserpw.php
+++ b/src/rest/changeuserpw.php
@@ -6,6 +6,10 @@ if(!checksession($link)) {
 }
 $id = $_SESSION['userid'];
 $newpass = $_POST['newpass'];
+// check length of password hash for pbkdf2
+if (strlen($newpass) > 130) {
+    die('0');
+}
 $accarray = json_decode($_POST['accarray']);
 $passarray = json_decode($_POST['passarray']);
 $salt = openssl_random_pseudo_bytes(32);

--- a/src/rest/check.php
+++ b/src/rest/check.php
@@ -24,6 +24,10 @@ if(!isset($_SESSION['random_login_stamp']) || $_SESSION['random_login_stamp'] ==
 }
 $usr = $_POST['user'];
 $pw = $_POST['pwd'];
+// check length of password hash for pbkdf2
+if (strlen($pw) > 130) {
+    die('0');
+}
 if($pw == ""||$usr == ""||$_POST['session_token'] == '') {
     die("0");
 }

--- a/src/rest/reg.php
+++ b/src/rest/reg.php
@@ -5,6 +5,10 @@ $email = $_POST['email'];
 if($pw == ''||$usr == ''||$email == "") {
     die("7");
 }
+// check length of password hash for pbkdf2
+if (strlen($pw) > 130) {
+    die('2');
+}
 if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
     die("5");
 }
@@ -13,6 +17,7 @@ if ($ALLOW_SIGN_UP === False){
     http_response_code(405);
     die('Method not allowed');
 }
+
 $link = sqllink();
 if(!$link) {
     die('6');


### PR DESCRIPTION
Calculating the pbkdf2 hash takes some time for huge input. As we already hash the input on the client side the "password" on the server side should never be longer than the hash.