### PR TITLE
Hide untrust button

### DIFF
--- a/src/js/common/backend.js
+++ b/src/js/common/backend.js
@@ -76,8 +76,9 @@ let AuthenticatedSession = (superclass) => class extends superclass {
         //Todo raise event
         localStorage.clear();
         var promises = [];
-        if (getCookie('device') != "") {
-            promises.push(self.doPost("deletepin", {user:getCookie('username'), device:getCookie('device')}));
+        var device = getCookie('device');
+        if ((device != null) && (device != "")) {
+            promises.push(self.doPost("deletepin", {'user': getCookie('username'), 'device': device}));
         }
         return Promise.all(promises)
             .then(function(){
@@ -203,10 +204,12 @@ let PinHandling = (superclass) => class extends superclass {
     getDevice() {
         var self = this;
         var device = getCookie('device');
-        if (device <= 0)
-            device = "";
-        if (device != "")
-            return Promise.resolve(device);
+        if (device != null) {
+            if (device <= 0)
+                device = "";
+            if (device != "")
+                return Promise.resolve(device);
+        }
         device =  self.encryptionWrapper.generatePassphrase(9);
         // check if this key is already used
         return self.doPost("getpinpk", { user:self.user, device: device, sig:'1'})
@@ -242,15 +245,17 @@ let PinHandling = (superclass) => class extends superclass {
     }
     delPin() {
         var self = this;
-        if(getCookie('device') != "") {
-            return self.doPost("deletepin", {user:getCookie('username'), device:getCookie('device')})
+        var device = getCookie('device');
+        if((device != null) && (device != "")) {
+            return self.doPost("deletepin", {'user': getCookie('username'), 'device': device})
                 .then(function(msg){
                     self.delLocalPinStore();
                 });
         }
     }
     get pinActive() {
-        return (getCookie('device') != "") && (this.usePin == 1);
+        var device = getCookie('device');
+        return ((device != null) && (device != "")) && (this.usePin != 0);
     }
 }
 

--- a/src/js/common/backend.js
+++ b/src/js/common/backend.js
@@ -249,6 +249,9 @@ let PinHandling = (superclass) => class extends superclass {
                 });
         }
     }
+    get pinActive() {
+        return (getCookie('device') != "") && (this.usePin == 1);
+    }
 }
 
 //mixin for localstorage
@@ -638,8 +641,5 @@ class LogonBackend extends mix(commonBackend).with(EventHandler, PinHandling) {
     checkHostdomain() {
         var full = location.protocol + '//' + location.hostname;
         return this.hostdomain.toLowerCase().startsWith(full.toLowerCase());
-    }
-    get pinActive() {
-        return (getCookie('device') != "") && (this.usePin == 1);
     }
 }

--- a/src/js/common/commonFunctions.js
+++ b/src/js/common/commonFunctions.js
@@ -85,13 +85,14 @@ function getCookie(cname) {
             return c.substring(name.length, c.length);
         }
     }
-    return "-1";
+    return null;
 }
 function setCookie(cname, cvalue) {
     document.cookie = cname + "=" + cvalue + ";path=/ ";
 }
 function deleteCookie(name) {
-   document.cookie = name + "=;expires=" + (new Date(0)).toGMTString();
+    setCookie(name, "");
+    document.cookie = name + "=;expires=" + (new Date(0)).toGMTString();
 }
 
 function sanitize_json(s){

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -593,6 +593,7 @@ $(document).ready(function(){
             });
     });
     $('#navBtnLogout').on('click',function(){ backend.logout(); });
+    $('#navBtnUntrust').toggle(backend.pinActive);
     $('#navBtnUntrust').on('click',function(){ quitpwd_untrust(); });
     $('#navBtnExport').on('click',function(){ exportcsv(); });
     $('#navBtnActivity').on('click',function(){


### PR DESCRIPTION
The untrust button is now only visible when a pin is set.
I changed the `getCookie` mechanism so it returns `null` when requested cookie is not set. This might also fix a problem when a user gets logged out immediately after logging in, but I'm not sure about that.