### PR TITLE
Fix timeouts by removing ServerRenew Cookie

### DIFF
--- a/src/function/config.php
+++ b/src/function/config.php
@@ -77,9 +77,6 @@ $SERVER_TIMEOUT = 1200; //seconds
 $SERVER_SOFT_TIMEOUT = 360; //seconds
 //Logout after x seconds of no interaction with server
 
-$SERVER_HARD_TIMEOUT = 1200; //seconds
-//Logout when x seconds after login have passed no matter what happened
-
 //SALT For Encryption
 //Don't change this section after you start using password-manager. Or you can't decrypt your password!
 //DON'T USE '\', IT CAN CAUSE PROBLEMS FOR BACKUP

--- a/src/function/config.php
+++ b/src/function/config.php
@@ -74,6 +74,12 @@ $BROWSER_TIMEOUT = 360; //seconds
 $SERVER_TIMEOUT = 1200; //seconds
 //Automatically logout (at server side) after 1200s since login
 
+$SERVER_SOFT_TIMEOUT = 360; //seconds
+//Logout after x seconds of no interaction with server
+
+$SERVER_HARD_TIMEOUT = 1200; //seconds
+//Logout when x seconds after login have passed no matter what happened
+
 //SALT For Encryption
 //Don't change this section after you start using password-manager. Or you can't decrypt your password!
 //DON'T USE '\', IT CAN CAUSE PROBLEMS FOR BACKUP

--- a/src/function/sqllink.php
+++ b/src/function/sqllink.php
@@ -4,7 +4,7 @@ $VERSION = '10.00';
 require_once dirname(__FILE__).'/config.php';
 function sqllink()
 {
-    global $DB_HOST,$DB_NAME,$DB_USER,$DB_PASSWORD;
+    global $DB_HOST, $DB_NAME, $DB_USER, $DB_PASSWORD;
     $dbhost = $DB_HOST;
     $dbname = $DB_NAME;
     $dbusr = $DB_USER;
@@ -43,7 +43,7 @@ function sqlquery($sql, $link)
 }
 function checksession($link, $refreshTimeout = true)
 {
-    global $SERVER_TIMEOUT, $HOSTDOMAIN;
+    global $SERVER_TIMEOUT, $SERVER_SOFT_TIMEOUT, $SERVER_HARD_TIMEOUT, $HOSTDOMAIN;
     session_start();
     if (!isset($_SESSION['loginok']) || $_SESSION['loginok'] != 1) {
         invalidateSession();

--- a/src/function/sqllink.php
+++ b/src/function/sqllink.php
@@ -67,7 +67,7 @@ function checksession($link, $refreshTimeout = true)
 
         return false;
     }
-    if ($_SESSION['refresh_time'] + $SERVER_SOFT_TIMEOUT < time() ) {
+    if ($_SESSION['refresh_time'] + $SERVER_SOFT_TIMEOUT < time()) {
         invalidateSession();
 
         return false;

--- a/src/function/sqllink.php
+++ b/src/function/sqllink.php
@@ -43,7 +43,7 @@ function sqlquery($sql, $link)
 }
 function checksession($link, $refreshTimeout = true)
 {
-    global $SERVER_TIMEOUT, $SERVER_SOFT_TIMEOUT, $SERVER_HARD_TIMEOUT, $HOSTDOMAIN;
+    global $SERVER_TIMEOUT, $SERVER_SOFT_TIMEOUT, $HOSTDOMAIN;
     session_start();
     if (!isset($_SESSION['loginok']) || $_SESSION['loginok'] != 1) {
         invalidateSession();
@@ -68,11 +68,6 @@ function checksession($link, $refreshTimeout = true)
         return false;
     }
     if ($_SESSION['refresh_time'] + $SERVER_SOFT_TIMEOUT < time() ) {
-        invalidateSession();
-
-        return false;
-    }
-    if ($_SESSION['create_time'] + $SERVER_HARD_TIMEOUT < time() ) {
         invalidateSession();
 
         return false;

--- a/src/js/common/backend.js
+++ b/src/js/common/backend.js
@@ -115,10 +115,11 @@ let Timeout = (superclass) => class extends superclass {
         }
     }
     sessionCountdown() {
+        var self = this;
         this.doPost('sessionAlive')
             .catch(function() {
-                this.logout("Session timed out");
-                this.clearTimeout();
+                self.logout("Session timed out");
+                self.clearTimeout();
             });
     }
     initTimeout() {

--- a/src/js/common/backend.js
+++ b/src/js/common/backend.js
@@ -114,7 +114,7 @@ let Timeout = (superclass) => class extends superclass {
             this.clearTimeout();
         }
     }
-    sessionCountdown() {
+    checkSession() {
         var self = this;
         this.doPost('sessionAlive')
             .catch(function() {
@@ -124,7 +124,7 @@ let Timeout = (superclass) => class extends superclass {
     }
     initTimeout() {
         this.countdownInterval = setInterval(this.clientCountdown.bind(this), 5000);
-        this.sessionCountdownInterval = setInterval(this.sessionCountdown.bind(this), 5000);
+        this.sessionCountdownInterval = setInterval(this.checkSession.bind(this), 5000);
     }
     clearTimeout() {
         clearInterval(this.sessionCountdownInterval);

--- a/src/js/common/backend.js
+++ b/src/js/common/backend.js
@@ -108,24 +108,21 @@ let Timeout = (superclass) => class extends superclass {
             this.timeout = newTimeout;
         }
     }
-    countdown() {
+    clientCountdown() {
         if (this.isTimeout) {
             this.logout("Logged out due to inactivity");
             this.clearTimeout();
         }
     }
     sessionCountdown() {
-        var ck = getCookie("ServerRenew");
-        if(ck == '1') // Reset timer
-            this.server_timeout  = this.default_server_timeout+Math.floor(Date.now() / 1000);
-        if(ck == "-1" || this.server_timeout < Math.floor(Date.now() / 1000)) { // Timer has expired
-            this.logout("Session timed out");
-            this.clearTimeout();
-        }
-        setCookie("ServerRenew", '0');// nothing happened
+        this.doPost('sessionAlive')
+            .catch(function() {
+                this.logout("Session timed out");
+                this.clearTimeout();
+            });
     }
     initTimeout() {
-        this.countdownInterval = setInterval(this.countdown.bind(this), 5000);
+        this.countdownInterval = setInterval(this.clientCountdown.bind(this), 5000);
         this.sessionCountdownInterval = setInterval(this.sessionCountdown.bind(this), 5000);
     }
     clearTimeout() {

--- a/src/logout.php
+++ b/src/logout.php
@@ -2,7 +2,7 @@
 
 require_once 'function/sqllink.php';
 session_start();
-logout();
+invalidateSession();
 $reason = '';
 if (isset($_GET['reason'])) {
     $reason .= '?reason='.urlencode($_GET['reason']);

--- a/src/rest/check.php
+++ b/src/rest/check.php
@@ -86,6 +86,6 @@ $_SESSION['userid'] = $record['id'];
 $_SESSION['pwd'] = $record['password'];
 $_SESSION['fields'] = $record['fields'];
 $_SESSION['create_time'] = time();
-setcookie('ServerRenew', '1', 0, '/');
+$_SESSION['refresh_time'] = time();
 loghistory($link, (int) $record['id'], getUserIP(), $_SERVER['HTTP_USER_AGENT'], 1);
 ajaxSuccess();

--- a/src/rest/logout.php
+++ b/src/rest/logout.php
@@ -3,6 +3,6 @@
 require_once dirname(__FILE__).'/../function/sqllink.php';
 require_once dirname(__FILE__).'/../function/ajax.php';
 session_start();
-logout();
+invalidateSession();
 //set the cookie so that other open pages get logged out too
 ajaxSuccess();

--- a/src/rest/sessionAlive.php
+++ b/src/rest/sessionAlive.php
@@ -1,0 +1,9 @@
+<?php
+
+require_once dirname(__FILE__).'/../function/sqllink.php';
+require_once dirname(__FILE__).'/../function/ajax.php';
+$link = sqllink();
+if (!checksession($link, false)) {
+    error('sessionUnauthenticated');
+}
+ajaxSuccess();


### PR DESCRIPTION
ServerRenew has issues with multiple open instances of the same session in different browser windows.
I fixed it by implementing a server side timeout.