### PR TITLE
Fix error "Undefined index: HTTP_X_FORWARDED_FOR"

### DIFF
--- a/src/rest/check.php
+++ b/src/rest/check.php
@@ -9,7 +9,7 @@ $_SESSION['session_token'] = $token;
 $sidvalue = session_id();
 function getUserIP()
 {
-    if ($_SERVER['HTTP_X_FORWARDED_FOR']) {
+    if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
         return $_SERVER['HTTP_X_FORWARDED_FOR'];
     }
 

--- a/src/rest/check.php
+++ b/src/rest/check.php
@@ -9,7 +9,7 @@ $_SESSION['session_token'] = $token;
 $sidvalue = session_id();
 function getUserIP()
 {
-    if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+    if (isset($_SERVER['HTTP_X_FORWARDED_FOR']) && $_SERVER['HTTP_X_FORWARDED_FOR']) {
         return $_SERVER['HTTP_X_FORWARDED_FOR'];
     }
 


### PR DESCRIPTION
On some configuration, `HTTP_X_FORWARDED_FOR` may not exist.
I don't find why it doesn't exist, but this quick fix prevents an error.