### PR TITLE
added parameters noopener, noreferrer for links to external sources

### DIFF
--- a/src/js/plugins/linkButton.js
+++ b/src/js/plugins/linkButton.js
@@ -13,6 +13,7 @@ registerPlugin("drawAccount",function(data){
         row.find(".namecell .cellOptionButton:last").before($('<a>')
             .attr('title',"Open")
             .attr('class','cellOptionButton')
+            .attr('rel','noopener noreferrer')
             .attr('href',addHttps(account["other"]["url"])) 
             .append($('<span></span>')
                 .attr('class','glyphicon glyphicon-globe')));


### PR DESCRIPTION
noreferrer: prevents leak of origin to third parties when clicking the link
noopener: prevent javascript access to window element by third parties (not strictly needed in this case)