### PR TITLE
Increase `ip` length for IPv6 support

### DIFF
--- a/initial.sql
+++ b/initial.sql
@@ -38,14 +38,14 @@ CREATE TABLE IF NOT EXISTS `pwdusrrecord` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `blockip` (
-  `ip` varchar(18) NOT NULL,
+  `ip` varchar(39) NOT NULL,
   `time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `history` (
   `id` int(11) NOT NULL,
   `userid` int(11) NOT NULL,
-  `ip` varchar(16) NOT NULL,
+  `ip` varchar(39) NOT NULL,
   `ua` varchar(500),
   `outcome` int(11) NOT NULL DEFAULT '0',
   `time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
When logging in from an IPv6 address, it dies from `Data too long for column 'ip'`. Increasing this length to 39 is enough for it to fit an address like `0123:4567:89ab:cdef:0123:4567:89ab:cdef`.

To test, both your home network and server must support IPv6, and an appropriate AAAA DNS record set up.

I'm unsure if the one in `blockip` needs to be increased any further, as I couldn't get Password Manager to try and write to it.